### PR TITLE
Fix hex string names when array is provided

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -53,8 +53,7 @@ export function parseMixedParam({ values, stringKey, numericKey }: FParseMixedPa
 	let query = "";
 
 	function addToQuery(value: string | number): void{
-		const type = isNaN(parseInt("" + value)) ? "string" : "number";
-		const key = type === "string" ? stringKey : numericKey;
+		const key = !isNumber(value) ? stringKey : numericKey;
 
 		query += `${key}=${value}&`;
 	}

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -39,5 +39,11 @@ describe.only("Unit tests for util functions", () => {
 			stringKey: "name",
 			numericKey: "id"
 		})).toBe("id=5023423&id=242342");
+
+		expect(parseMixedParam({
+			values: ["0xdeadbeef", 'shroud'],
+			stringKey: "user_login",
+			numericKey: "user_id"
+		})).toBe("user_login=0xdeadbeef&user_login=shroud");
 	});
 });


### PR DESCRIPTION
Hey @Plazide,

Long time no see 😅 

Seems that I forgot to fix the check when an array is provided.

A different check was done on `parseMixedParam` to check if a value was a number or not.

Tests are updated too 👍 