### PR TITLE
Added `getGlobalBadges`, `getChannelBadges` and `getGlobalEmotes` endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-twitch",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "A wrapper for the Helix Twitch API in NodeJS.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ import {
 	APIExtensionResponse,
 	APIActiveUserExtensionResponse,
 	APICreateClipResponse,
-	APIModeratorResponse, APICodeStatusResponse, APICommercialResponse, APIChannelEmotesResponse, APIBadgesResponse
+	APIModeratorResponse, APICodeStatusResponse, APICommercialResponse, APIEmotesResponse, APIBadgesResponse
 } from "./types/responses";
 
 /** Twitch API */
@@ -467,6 +467,11 @@ export default class TwitchApi extends EventEmitter{
 		return this._get<APIBadgesResponse>(endpoint);
 	}
 
+	async getGlobalEmotes(): Promise<APIEmotesResponse>{
+		const endpoint = "/chat/emotes/global";
+		return this._get<APIEmotesResponse>(endpoint);
+	}
+
 	/** Fetch videos by a user id, game id, or one or more video ids. Only one of these can be specified at a time. */
 	async getVideos(options: GetVideosOptions): Promise<APIVideoResponse>{
 		let query = "?";
@@ -524,7 +529,7 @@ export default class TwitchApi extends EventEmitter{
 		return this._get<APICheermoteResponse>(endpoint);
 	}
 
-	async getChannelEmotes(broadcasterId: string): Promise<APIChannelEmotesResponse>{
+	async getChannelEmotes(broadcasterId: string): Promise<APIEmotesResponse>{
 		const query = `?broadcaster_id=${broadcasterId}`;
 		const endpoint = `/chat/emotes${query}`;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ import {
 	APIExtensionResponse,
 	APIActiveUserExtensionResponse,
 	APICreateClipResponse,
-	APIModeratorResponse, APICodeStatusResponse, APICommercialResponse, APIChannelEmotesResponse
+	APIModeratorResponse, APICodeStatusResponse, APICommercialResponse, APIChannelEmotesResponse, APIBadgesResponse
 } from "./types/responses";
 
 /** Twitch API */
@@ -462,6 +462,11 @@ export default class TwitchApi extends EventEmitter{
 		return this._get<APITagResponse>(endpoint);
 	}
 
+	async getGlobalBadges(): Promise<APIBadgesResponse>{
+		const endpoint = "/chat/badges/global";
+		return this._get<APIBadgesResponse>(endpoint);
+	}
+
 	/** Fetch videos by a user id, game id, or one or more video ids. Only one of these can be specified at a time. */
 	async getVideos(options: GetVideosOptions): Promise<APIVideoResponse>{
 		let query = "?";
@@ -524,6 +529,13 @@ export default class TwitchApi extends EventEmitter{
 		const endpoint = `/chat/emotes${query}`;
 
 		return this._get(endpoint);
+	}
+
+	async getChannelBadges(broadcasterId: string): Promise<APIBadgesResponse>{
+		const query = `?broadcaster_id=${broadcasterId}`;
+		const endpoint = `/chat/badges${query}`;
+
+		return this._get<APIBadgesResponse>(endpoint);
 	}
 
 	/*********************************

--- a/src/types/objects.ts
+++ b/src/types/objects.ts
@@ -635,9 +635,9 @@ export interface Badge{
 	set_id: string;
 	versions: {
 		id: string,
-		url_1x: string,
-		url_2x: string,
-		url_4x: string
+		image_url_1x: string,
+		image_url_2x: string,
+		image_url_4x: string
 	}[]
 }
 

--- a/src/types/objects.ts
+++ b/src/types/objects.ts
@@ -630,4 +630,15 @@ export interface Commercial{
 	retry_after: number;
 }
 
+export interface Badge{
+	/** The ID of the badge. */
+	set_id: string;
+	versions: {
+		id: string,
+		url_1x: string,
+		url_2x: string,
+		url_4x: string
+	}[]
+}
+
 export type CommercialLength = 30 | 60 | 90 | 120 | 150 | 180;

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -340,6 +340,13 @@ export interface GetModeratorsOptions{
 	after?: string;
 }
 
+export interface GetChannelChatBadges{
+	/** Provided `broadcaster_id` must match the `user_id` in the auth token.
+
+		Maximum: 1 */
+	broadcaster_id: string;
+}
+
 export interface BaseOptions{
 	/** Maximum number of objects to return. Maximum: 100. Default: 20. */
 	first?: number;

--- a/src/types/responses.ts
+++ b/src/types/responses.ts
@@ -104,7 +104,7 @@ export interface APICheermoteResponse{
 	data: Cheermote[];
 }
 
-export interface APIChannelEmotesResponse{
+export interface APIEmotesResponse{
 	data: Emote[];
 
 	/** A templated URL. Use the values from id, format, scale, and theme_mode to replace the like-named placeholder strings in the templated URL to create a CDN (content delivery network) URL that you use to fetch the emote.

--- a/src/types/responses.ts
+++ b/src/types/responses.ts
@@ -21,7 +21,7 @@ import {
 	Extension,
 	ActiveExtension,
 	CreatedClip,
-	Moderator, CodeStatus, Commercial
+	Moderator, CodeStatus, Commercial, Badge
 } from "./objects";
 
 export interface APIBaseResponse{
@@ -137,4 +137,8 @@ export interface APIBitsLeaderboardResponse{
 
 export interface APICommercialResponse{
 	data: Commercial[];
+}
+
+export interface APIBadgesResponse{
+	data: Badge[];
 }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -92,6 +92,12 @@ describe("unit tests for endpoint NOT requiring user authentication.", () => {
 		expect(result.data).toBeInstanceOf(Array);
 	});
 
+	test("`getGlobalEmotes` should return array of emotes", async () => {
+		const result = await api.getGlobalEmotes();
+
+		expect(result.data).toBeInstanceOf(Array);
+	});
+
 	test("`getCheermotes` should return array of cheermotes", async () => {
 		const result = await api.getCheermotes();
 

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -86,6 +86,12 @@ describe("unit tests for endpoint NOT requiring user authentication.", () => {
 		expect(result.data).toBeInstanceOf(Array);
 	});
 
+	test("`getGlobalBadges` should return array of badges", async () => {
+		const result = await api.getGlobalBadges();
+
+		expect(result.data).toBeInstanceOf(Array);
+	});
+
 	test("`getCheermotes` should return array of cheermotes", async () => {
 		const result = await api.getCheermotes();
 
@@ -109,6 +115,12 @@ describe("unit tests for endpoint NOT requiring user authentication.", () => {
 
 		expect(result.data).toBeInstanceOf(Array);
 		expect(typeof result.template).toBe("string");
+	});
+
+	test("Should get channel badges", async () => {
+		const result = await api.getChannelBadges(broadcasterId);
+
+		expect(result.data).toBeInstanceOf(Array);
 	});
 });
 


### PR DESCRIPTION
Just a small addition, it should be clear for contributors that `data/apiUser.ts` needs to be added and filled with a valid twitch application and all scopes and callback url of `http://localhost:5000`